### PR TITLE
Add coverage tasks using Go's built-in tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.db-wal
 *.db-shm
 coverage.out
+coverage.html
 .task/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ last-viewed issue are persisted at `~/.config/jui/state.json`.
 
 ```sh
 task test       # go test ./...
+task cover      # tests + per-function coverage summary
+task cover:html # writes coverage.html
 task vet        # go vet ./...
 task run -- doctor
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,8 @@ version: '3'
 vars:
   BINARY: jira
   PKG: ./...
+  COVERAGE: coverage.out
+  COVERAGE_HTML: coverage.html
 
 tasks:
   default:
@@ -32,6 +34,18 @@ tasks:
     cmds:
       - go test {{.PKG}}
 
+  cover:
+    desc: Run tests with coverage and print a per-function summary
+    cmds:
+      - go test -coverprofile={{.COVERAGE}} -covermode=atomic {{.PKG}}
+      - go tool cover -func={{.COVERAGE}}
+
+  cover:html:
+    desc: Generate an HTML coverage report at coverage.html
+    deps: [cover]
+    cmds:
+      - go tool cover -html={{.COVERAGE}} -o {{.COVERAGE_HTML}}
+
   vet:
     desc: Run go vet
     cmds:
@@ -46,4 +60,5 @@ tasks:
     desc: Remove build artifacts
     cmds:
       - rm -f {{.BINARY}}
+      - rm -f {{.COVERAGE}} {{.COVERAGE_HTML}}
       - rm -rf dist


### PR DESCRIPTION
Wires up `task cover` (per-function summary) and `task cover:html` (HTML
report) on top of `go test -coverprofile` and `go tool cover`. The HTML
artifact is gitignored and `task clean` removes both coverage files.

https://claude.ai/code/session_01444ygdLByP3esrzrHncE5f