### PR TITLE
Add Go coverage tasks and a Jira API mock for tests

### DIFF
--- a/internal/jiramock/adf.go
+++ b/internal/jiramock/adf.go
@@ -1,0 +1,49 @@
+package jiramock
+
+import "encoding/json"
+
+// adfDoc is the minimal Atlassian Document Format envelope. See
+// https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/.
+type adfDoc struct {
+	Type    string    `json:"type"`
+	Version int       `json:"version"`
+	Content []adfNode `json:"content"`
+}
+
+type adfNode struct {
+	Type    string         `json:"type"`
+	Attrs   map[string]any `json:"attrs,omitempty"`
+	Text    string         `json:"text,omitempty"`
+	Marks   []adfMark      `json:"marks,omitempty"`
+	Content []adfNode      `json:"content,omitempty"`
+}
+
+type adfMark struct {
+	Type  string         `json:"type"`
+	Attrs map[string]any `json:"attrs,omitempty"`
+}
+
+// adfFromText wraps plain text in a single-paragraph ADF document. Empty
+// input returns an empty doc rather than nil so the field round-trips.
+func adfFromText(s string) adfDoc {
+	if s == "" {
+		return adfDoc{Type: "doc", Version: 1, Content: []adfNode{}}
+	}
+	return adfDoc{
+		Type:    "doc",
+		Version: 1,
+		Content: []adfNode{{
+			Type:    "paragraph",
+			Content: []adfNode{{Type: "text", Text: s}},
+		}},
+	}
+}
+
+// pickADF returns rawADF as an arbitrary JSON value if non-empty,
+// otherwise an ADF doc wrapping fallback.
+func pickADF(rawADF json.RawMessage, fallback string) any {
+	if len(rawADF) > 0 {
+		return rawADF
+	}
+	return adfFromText(fallback)
+}

--- a/internal/jiramock/jiramock.go
+++ b/internal/jiramock/jiramock.go
@@ -1,0 +1,549 @@
+// Package jiramock is an in-memory mock of the Atlassian Jira Cloud
+// REST API v3. Response shapes match Atlassian's published OpenAPI
+// schema (see https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json),
+// so a *jira.Client wired to a mock server.URL exercises real request
+// building, retry behaviour, and JSON decoding.
+//
+// Endpoints served:
+//
+//   - GET /rest/api/3/myself              -> User
+//   - GET /rest/api/3/issue/{key}         -> IssueBean
+//   - GET /rest/api/3/issue/{key}/comment -> PageOfComments
+//   - GET /rest/api/3/search/jql          -> SearchAndReconcileResults
+//
+// Typical use:
+//
+//	srv := jiramock.New()
+//	defer srv.Close()
+//	srv.SetMyself(jiramock.User{AccountID: "acc-me", DisplayName: "Me"})
+//	srv.AddIssue(jiramock.Issue{Key: "ABC-1", Summary: "Boom", ...})
+//
+//	c, _ := jira.New(jira.Config{BaseURL: srv.URL(), Email: "x", Token: "y"})
+//	got, _ := c.Issue(context.Background(), "ABC-1")
+package jiramock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// -----------------------------------------------------------------------------
+// Public types
+// -----------------------------------------------------------------------------
+
+// User is a test-friendly user, expanded into the full schema on the wire.
+type User struct {
+	AccountID    string
+	DisplayName  string
+	EmailAddress string
+	AccountType  string // "atlassian", "app", "customer"; defaults to "atlassian"
+}
+
+// Issue is a test-friendly issue. Description is plain text; it's wrapped
+// in a single-paragraph ADF doc unless DescriptionADF is set.
+type Issue struct {
+	ID             string
+	Key            string
+	ProjectKey     string
+	Summary        string
+	Description    string
+	DescriptionADF json.RawMessage
+	Type           string
+	Status         string
+	StatusCategory string // "new", "indeterminate", "done"
+	Priority       string
+	Assignee       *User
+	Reporter       *User
+	Labels         []string
+	DueDate        time.Time // zero = unset
+	Created        time.Time
+	Updated        time.Time
+}
+
+// Comment is a test-friendly comment.
+type Comment struct {
+	ID      string
+	Author  *User
+	Body    string
+	BodyADF json.RawMessage
+	Created time.Time
+	Updated time.Time
+}
+
+// Fault forces non-2xx responses for matching requests. Status, RetryAfter,
+// and Body define the failure; Times bounds how often it fires (0 = once).
+// Method "" matches any. Path is matched against the request path with
+// path.Match — use "*" wildcards.
+type Fault struct {
+	Method     string
+	Path       string
+	Status     int
+	Body       string
+	RetryAfter string
+	Times      int
+}
+
+// Request is a recorded HTTP call.
+type Request struct {
+	Method string
+	Path   string
+	Query  url.Values
+}
+
+// -----------------------------------------------------------------------------
+// Server
+// -----------------------------------------------------------------------------
+
+// Server is the in-memory mock. Construct with New, dispose with Close.
+type Server struct {
+	httpsrv *httptest.Server
+
+	mu       sync.Mutex
+	me       *User
+	issues   map[string]*Issue
+	comments map[string][]*Comment
+	pageSize int
+	faults   []Fault
+	requests []Request
+}
+
+// New starts a mock server with no data. Call Close when done.
+func New() *Server {
+	s := &Server{
+		issues:   map[string]*Issue{},
+		comments: map[string][]*Comment{},
+		pageSize: 100,
+	}
+	s.httpsrv = httptest.NewServer(http.HandlerFunc(s.serve))
+	return s
+}
+
+// URL returns the server's base URL, suitable for jira.Config.BaseURL.
+func (s *Server) URL() string { return s.httpsrv.URL }
+
+// Close shuts the server down.
+func (s *Server) Close() { s.httpsrv.Close() }
+
+// SetPageSize controls how many issues a /search/jql page returns. Default 100.
+func (s *Server) SetPageSize(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n > 0 {
+		s.pageSize = n
+	}
+}
+
+// SetMyself sets the user returned by GET /rest/api/3/myself.
+func (s *Server) SetMyself(u User) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	uu := u
+	s.me = &uu
+}
+
+// AddIssue registers (or replaces) an issue. Key is required.
+func (s *Server) AddIssue(iss Issue) {
+	if iss.Key == "" {
+		panic("jiramock: AddIssue requires Key")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := iss
+	if cp.ID == "" {
+		cp.ID = "10" + cp.Key
+	}
+	if cp.ProjectKey == "" {
+		if i := strings.IndexByte(cp.Key, '-'); i > 0 {
+			cp.ProjectKey = cp.Key[:i]
+		}
+	}
+	s.issues[cp.Key] = &cp
+}
+
+// AddComment appends a comment to an issue.
+func (s *Server) AddComment(issueKey string, c Comment) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := c
+	s.comments[issueKey] = append(s.comments[issueKey], &cp)
+}
+
+// Reset clears all data, faults, and recorded requests.
+func (s *Server) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.me = nil
+	s.issues = map[string]*Issue{}
+	s.comments = map[string][]*Comment{}
+	s.faults = nil
+	s.requests = nil
+}
+
+// InjectFault enqueues a fault. Faults fire in the order they were added,
+// each consuming one match before the next is considered.
+func (s *Server) InjectFault(f Fault) {
+	if f.Times <= 0 {
+		f.Times = 1
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.faults = append(s.faults, f)
+}
+
+// Requests returns a copy of the recorded request log.
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Request, len(s.requests))
+	copy(out, s.requests)
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// HTTP handler
+// -----------------------------------------------------------------------------
+
+func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.requests = append(s.requests, Request{
+		Method: r.Method, Path: r.URL.Path, Query: cloneValues(r.URL.Query()),
+	})
+	if f := s.matchFault(r); f != nil {
+		if f.RetryAfter != "" {
+			w.Header().Set("Retry-After", f.RetryAfter)
+		}
+		body := f.Body
+		if body == "" {
+			body = `{"errorMessages":["injected fault"]}`
+		}
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.Status)
+		_, _ = w.Write([]byte(body))
+		return
+	}
+	s.mu.Unlock()
+
+	switch {
+	case r.URL.Path == "/rest/api/3/myself":
+		s.handleMyself(w, r)
+	case r.URL.Path == "/rest/api/3/search/jql":
+		s.handleSearch(w, r)
+	case strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/"):
+		rest := strings.TrimPrefix(r.URL.Path, "/rest/api/3/issue/")
+		// rest is "KEY" or "KEY/comment"
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			key, sub := rest[:i], rest[i+1:]
+			if sub == "comment" {
+				s.handleComments(w, r, key)
+				return
+			}
+		}
+		s.handleIssue(w, r, rest)
+	default:
+		writeError(w, http.StatusNotFound, "no such endpoint: "+r.URL.Path)
+	}
+}
+
+// matchFault must be called with s.mu held. It returns the next matching
+// fault and decrements its Times counter, removing it when exhausted.
+func (s *Server) matchFault(r *http.Request) *Fault {
+	for i := range s.faults {
+		f := &s.faults[i]
+		if f.Method != "" && !strings.EqualFold(f.Method, r.Method) {
+			continue
+		}
+		if f.Path != "" {
+			ok, _ := path.Match(f.Path, r.URL.Path)
+			if !ok && f.Path != r.URL.Path {
+				continue
+			}
+		}
+		out := *f
+		f.Times--
+		if f.Times <= 0 {
+			s.faults = append(s.faults[:i], s.faults[i+1:]...)
+		}
+		return &out
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// /myself
+// -----------------------------------------------------------------------------
+
+func (s *Server) handleMyself(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	s.mu.Lock()
+	me := s.me
+	s.mu.Unlock()
+	if me == nil {
+		writeError(w, http.StatusUnauthorized, "no current user configured")
+		return
+	}
+	writeJSON(w, http.StatusOK, toWireUser(s.URL(), me))
+}
+
+// -----------------------------------------------------------------------------
+// /issue/{key}
+// -----------------------------------------------------------------------------
+
+func (s *Server) handleIssue(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	keyDecoded, err := url.PathUnescape(key)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad key")
+		return
+	}
+	s.mu.Lock()
+	iss, ok := s.issues[keyDecoded]
+	s.mu.Unlock()
+	if !ok {
+		writeError(w, http.StatusNotFound, "issue does not exist")
+		return
+	}
+	writeJSON(w, http.StatusOK, toWireIssue(s.URL(), iss))
+}
+
+// -----------------------------------------------------------------------------
+// /issue/{key}/comment
+// -----------------------------------------------------------------------------
+
+func (s *Server) handleComments(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	keyDecoded, _ := url.PathUnescape(key)
+	s.mu.Lock()
+	if _, ok := s.issues[keyDecoded]; !ok {
+		s.mu.Unlock()
+		writeError(w, http.StatusNotFound, "issue does not exist")
+		return
+	}
+	cs := s.comments[keyDecoded]
+	out := make([]wireComment, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, toWireComment(s.URL(), keyDecoded, c))
+	}
+	s.mu.Unlock()
+	writeJSON(w, http.StatusOK, wireCommentsPage{
+		Comments:   out,
+		StartAt:    0,
+		MaxResults: len(out),
+		Total:      len(out),
+	})
+}
+
+// -----------------------------------------------------------------------------
+// /search/jql
+// -----------------------------------------------------------------------------
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	q := r.URL.Query()
+	jql := q.Get("jql")
+	tok := q.Get("nextPageToken")
+	filt := parseJQL(jql)
+
+	s.mu.Lock()
+	all := make([]*Issue, 0, len(s.issues))
+	for _, iss := range s.issues {
+		if !matches(iss, filt) {
+			continue
+		}
+		all = append(all, iss)
+	}
+	pageSize := s.pageSize
+	base := s.URL()
+	s.mu.Unlock()
+
+	sort.Slice(all, func(i, j int) bool {
+		if filt.orderDesc {
+			return all[i].Updated.After(all[j].Updated)
+		}
+		return all[i].Updated.Before(all[j].Updated)
+	})
+
+	offset := 0
+	if tok != "" {
+		if n, err := strconv.Atoi(tok); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	end := offset + pageSize
+	if end > len(all) {
+		end = len(all)
+	}
+	page := all[offset:end]
+
+	wireIssues := make([]wireIssue, 0, len(page))
+	for _, iss := range page {
+		wireIssues = append(wireIssues, toWireIssue(base, iss))
+	}
+	resp := wireSearchPage{Issues: wireIssues, IsLast: end >= len(all)}
+	if !resp.IsLast {
+		resp.NextPageToken = strconv.Itoa(end)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func matches(iss *Issue, f jqlFilter) bool {
+	if f.project != "" && !strings.EqualFold(iss.ProjectKey, f.project) {
+		return false
+	}
+	if f.updatedSince != nil && iss.Updated.Before(*f.updatedSince) {
+		return false
+	}
+	return true
+}
+
+// -----------------------------------------------------------------------------
+// Wire conversion
+// -----------------------------------------------------------------------------
+
+func toWireUser(base string, u *User) *wireUser {
+	if u == nil {
+		return nil
+	}
+	at := u.AccountType
+	if at == "" {
+		at = "atlassian"
+	}
+	w := &wireUser{
+		AccountID:    u.AccountID,
+		DisplayName:  u.DisplayName,
+		EmailAddress: u.EmailAddress,
+		AccountType:  at,
+		Active:       true,
+	}
+	if u.AccountID != "" {
+		w.Self = base + "/rest/api/3/user?accountId=" + url.QueryEscape(u.AccountID)
+	}
+	return w
+}
+
+func toWireIssue(base string, iss *Issue) wireIssue {
+	prio := (*wireNamed)(nil)
+	if iss.Priority != "" {
+		prio = &wireNamed{Name: iss.Priority}
+	}
+	cat := iss.StatusCategory
+	if cat == "" {
+		cat = "new"
+	}
+	due := ""
+	if !iss.DueDate.IsZero() {
+		due = iss.DueDate.Format("2006-01-02")
+	}
+	return wireIssue{
+		ID:   iss.ID,
+		Self: base + "/rest/api/3/issue/" + iss.ID,
+		Key:  iss.Key,
+		Fields: wireIssueFields{
+			Summary:     iss.Summary,
+			Description: pickADF(iss.DescriptionADF, iss.Description),
+			IssueType:   wireNamed{Name: defaultStr(iss.Type, "Task")},
+			Status: wireStatus{
+				Name:           defaultStr(iss.Status, "To Do"),
+				StatusCategory: wireStatusCategory{Key: cat, Name: cat},
+			},
+			Priority:  prio,
+			Project:   wireProject{Key: iss.ProjectKey},
+			Assignee:  toWireUser(base, iss.Assignee),
+			Reporter:  toWireUser(base, iss.Reporter),
+			Labels:    append([]string(nil), iss.Labels...),
+			DueDate:   due,
+			Created:   formatJiraTime(iss.Created),
+			Updated:   formatJiraTime(iss.Updated),
+		},
+	}
+}
+
+func toWireComment(base, issueKey string, c *Comment) wireComment {
+	return wireComment{
+		ID:        c.ID,
+		Self:      base + "/rest/api/3/issue/" + issueKey + "/comment/" + c.ID,
+		Author:    toWireUser(base, c.Author),
+		Body:      pickADF(c.BodyADF, c.Body),
+		Created:   formatJiraTime(c.Created),
+		Updated:   formatJiraTime(c.Updated),
+		JsdPublic: true,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+// formatJiraTime emits the Atlassian wire format: 2026-04-20T11:30:00.000+0000.
+func formatJiraTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02T15:04:05.000-0700")
+}
+
+func defaultStr(s, dflt string) string {
+	if s == "" {
+		return dflt
+	}
+	return s
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(wireErrorCollection{
+		ErrorMessages: []string{msg},
+		Status:        code,
+	})
+}
+
+func cloneValues(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vs := range v {
+		cp := make([]string, len(vs))
+		copy(cp, vs)
+		out[k] = cp
+	}
+	return out
+}
+
+// String returns a debug representation of the server state (issue keys, fault count).
+// Useful in test failure messages.
+func (s *Server) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, len(s.issues))
+	for k := range s.issues {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("jiramock{issues=%v faults=%d reqs=%d}", keys, len(s.faults), len(s.requests))
+}

--- a/internal/jiramock/jiramock_test.go
+++ b/internal/jiramock/jiramock_test.go
@@ -1,0 +1,368 @@
+package jiramock_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anttti/j/internal/jira"
+	"github.com/anttti/j/internal/jiramock"
+)
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+func newClient(t *testing.T, srv *jiramock.Server) *jira.Client {
+	t.Helper()
+	c, err := jira.New(jira.Config{
+		BaseURL: srv.URL(),
+		Email:   "me@example.com",
+		Token:   "tok",
+	}, jira.WithSleeper(func(time.Duration) {}))
+	if err != nil {
+		t.Fatalf("jira.New: %v", err)
+	}
+	return c
+}
+
+var t0 = time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+// -----------------------------------------------------------------------------
+// schema fidelity: raw HTTP shape matches Atlassian's docs
+// -----------------------------------------------------------------------------
+
+func TestServer_IssueResponseShapeMatchesSchema(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.AddIssue(jiramock.Issue{
+		Key:            "ABC-1",
+		Summary:        "Boom",
+		Description:    "It exploded.",
+		Type:           "Bug",
+		Status:         "In Progress",
+		StatusCategory: "indeterminate",
+		Priority:       "High",
+		Labels:         []string{"flaky"},
+		Created:        t0,
+		Updated:        t0.Add(time.Hour),
+		Assignee:       &jiramock.User{AccountID: "acc-a", DisplayName: "Alice"},
+	})
+
+	resp, err := http.Get(srv.URL() + "/rest/api/3/issue/ABC-1")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode: %v\nbody=%s", err, body)
+	}
+	// Top-level keys per IssueBean.
+	for _, k := range []string{"id", "key", "self", "fields"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing top-level key %q in %s", k, body)
+		}
+	}
+	fields, _ := got["fields"].(map[string]any)
+	for _, k := range []string{"summary", "description", "issuetype", "status", "project", "labels", "created", "updated"} {
+		if _, ok := fields[k]; !ok {
+			t.Errorf("missing fields.%s in %s", k, body)
+		}
+	}
+	// Description must be an ADF doc.
+	desc, _ := fields["description"].(map[string]any)
+	if desc["type"] != "doc" {
+		t.Errorf("description not an ADF doc: %v", desc)
+	}
+	// Status must carry a statusCategory.key.
+	status, _ := fields["status"].(map[string]any)
+	cat, _ := status["statusCategory"].(map[string]any)
+	if cat["key"] != "indeterminate" {
+		t.Errorf("status.statusCategory.key=%v want indeterminate", cat["key"])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// end-to-end: real *jira.Client decodes mock JSON
+// -----------------------------------------------------------------------------
+
+func TestClient_Myself_AgainstMock(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.SetMyself(jiramock.User{AccountID: "acc-me", DisplayName: "Me", EmailAddress: "me@example.com"})
+
+	c := newClient(t, srv)
+	u, err := c.Myself(context.Background())
+	if err != nil {
+		t.Fatalf("Myself: %v", err)
+	}
+	if u.AccountID != "acc-me" || u.DisplayName != "Me" || u.Email != "me@example.com" {
+		t.Fatalf("got %+v", u)
+	}
+}
+
+func TestClient_Myself_NotConfiguredIs401(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	c := newClient(t, srv)
+	if _, err := c.Myself(context.Background()); err == nil {
+		t.Fatalf("expected error when no user configured")
+	}
+}
+
+func TestClient_Issue_RoundTrip(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.AddIssue(jiramock.Issue{
+		Key:            "ABC-1",
+		Summary:        "Fix login",
+		Description:    "Login is flaky.",
+		Type:           "Bug",
+		Status:         "In Progress",
+		StatusCategory: "indeterminate",
+		Priority:       "High",
+		Assignee:       &jiramock.User{AccountID: "acc-a", DisplayName: "Alice", EmailAddress: "a@x"},
+		Reporter:       &jiramock.User{AccountID: "acc-b", DisplayName: "Bob"},
+		Labels:         []string{"flaky", "auth"},
+		DueDate:        time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Created:        t0,
+		Updated:        t0.Add(90 * time.Minute),
+	})
+	c := newClient(t, srv)
+	entry, err := c.Issue(context.Background(), "ABC-1")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	iss := entry.Issue
+	if iss.Key != "ABC-1" || iss.ProjectKey != "ABC" {
+		t.Fatalf("ids: %+v", iss.IssueRef)
+	}
+	if iss.Type != "Bug" || iss.Status != "In Progress" || iss.StatusCategory != "indeterminate" {
+		t.Fatalf("type/status: %+v", iss)
+	}
+	if iss.Priority != "High" {
+		t.Fatalf("priority=%q", iss.Priority)
+	}
+	if iss.Assignee == nil || iss.Assignee.DisplayName != "Alice" {
+		t.Fatalf("assignee: %+v", iss.Assignee)
+	}
+	if iss.Reporter == nil || iss.Reporter.AccountID != "acc-b" {
+		t.Fatalf("reporter: %+v", iss.Reporter)
+	}
+	if len(iss.Labels) != 2 || iss.Labels[1] != "auth" {
+		t.Fatalf("labels: %+v", iss.Labels)
+	}
+	if iss.DueDate == nil || iss.DueDate.Format("2006-01-02") != "2026-05-01" {
+		t.Fatalf("due: %+v", iss.DueDate)
+	}
+	if !iss.Created.Equal(t0) || !iss.Updated.Equal(t0.Add(90*time.Minute)) {
+		t.Fatalf("times: %v / %v", iss.Created, iss.Updated)
+	}
+	if !strings.Contains(iss.Description, "Login is flaky") {
+		t.Fatalf("desc not rendered: %q", iss.Description)
+	}
+	if !strings.HasSuffix(iss.URL, "/browse/ABC-1") {
+		t.Fatalf("url: %q", iss.URL)
+	}
+}
+
+func TestClient_Issue_MissingIs404(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	c := newClient(t, srv)
+	_, err := c.Issue(context.Background(), "NOPE-1")
+	if err == nil || !jira.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// search + pagination
+// -----------------------------------------------------------------------------
+
+func TestClient_Search_PaginatesAndFiltersByProject(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.SetPageSize(2)
+	for i := 1; i <= 5; i++ {
+		srv.AddIssue(jiramock.Issue{
+			Key:        fmtKey("ABC", i),
+			Summary:    "issue",
+			Updated:    t0.Add(time.Duration(i) * time.Minute),
+			Created:    t0,
+			Type:       "Task",
+			Status:     "To Do",
+			ProjectKey: "ABC",
+		})
+	}
+	// One issue in another project — must be filtered out.
+	srv.AddIssue(jiramock.Issue{Key: "OTHER-1", ProjectKey: "OTHER", Updated: t0, Created: t0})
+
+	c := newClient(t, srv)
+	var keys []string
+	tok := ""
+	for i := 0; i < 10; i++ {
+		page, err := c.Search(context.Background(), "project = ABC ORDER BY updated ASC", tok)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		for _, e := range page.Entries {
+			keys = append(keys, e.Issue.Key)
+		}
+		if page.IsLast {
+			break
+		}
+		tok = page.NextPageToken
+	}
+	want := []string{"ABC-1", "ABC-2", "ABC-3", "ABC-4", "ABC-5"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("got %v want %v", keys, want)
+	}
+
+	// Verify we paginated rather than slurping everything in one page.
+	calls := 0
+	for _, r := range srv.Requests() {
+		if r.Path == "/rest/api/3/search/jql" {
+			calls++
+		}
+	}
+	if calls < 3 {
+		t.Fatalf("expected >=3 search calls (page size 2 over 5 issues), got %d", calls)
+	}
+}
+
+func TestClient_Search_RespectsUpdatedSinceClause(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.AddIssue(jiramock.Issue{Key: "ABC-1", ProjectKey: "ABC", Updated: t0})
+	srv.AddIssue(jiramock.Issue{Key: "ABC-2", ProjectKey: "ABC", Updated: t0.Add(2 * time.Hour)})
+
+	c := newClient(t, srv)
+	cutoff := t0.Add(time.Hour).Format("2006-01-02 15:04")
+	jql := `(project = ABC) AND updated >= "` + cutoff + `" ORDER BY updated ASC`
+	page, err := c.Search(context.Background(), jql, "")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(page.Entries) != 1 || page.Entries[0].Issue.Key != "ABC-2" {
+		t.Fatalf("expected only ABC-2, got %+v", keysOf(page))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// comments
+// -----------------------------------------------------------------------------
+
+func TestClient_Comments_RoundTrip(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.AddIssue(jiramock.Issue{Key: "ABC-1", ProjectKey: "ABC", Updated: t0})
+	srv.AddComment("ABC-1", jiramock.Comment{
+		ID:      "c1",
+		Author:  &jiramock.User{AccountID: "acc-a", DisplayName: "Alice"},
+		Body:    "Looks good",
+		Created: t0,
+		Updated: t0,
+	})
+	srv.AddComment("ABC-1", jiramock.Comment{
+		ID:      "c2",
+		Author:  &jiramock.User{DisplayName: "Bob"},
+		Body:    "Done",
+		Created: t0.Add(time.Minute),
+		Updated: t0.Add(time.Minute),
+	})
+
+	c := newClient(t, srv)
+	cs, err := c.Comments(context.Background(), "ABC-1")
+	if err != nil {
+		t.Fatalf("Comments: %v", err)
+	}
+	if len(cs) != 2 || cs[0].ID != "c1" || cs[1].Body != "Done" {
+		t.Fatalf("comments: %+v", cs)
+	}
+	if cs[0].Author == nil || cs[0].Author.DisplayName != "Alice" {
+		t.Fatalf("author: %+v", cs[0].Author)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// fault injection
+// -----------------------------------------------------------------------------
+
+func TestServer_FaultInjection_429ThenSuccess(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.SetMyself(jiramock.User{AccountID: "acc-me", DisplayName: "Me"})
+	srv.InjectFault(jiramock.Fault{
+		Path: "/rest/api/3/myself", Status: 429, RetryAfter: "0", Times: 2,
+	})
+	c := newClient(t, srv)
+	if _, err := c.Myself(context.Background()); err != nil {
+		t.Fatalf("Myself after retries: %v", err)
+	}
+	calls := 0
+	for _, r := range srv.Requests() {
+		if r.Path == "/rest/api/3/myself" {
+			calls++
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (2 fault + 1 success), got %d", calls)
+	}
+}
+
+func TestServer_Reset_ClearsState(t *testing.T) {
+	srv := jiramock.New()
+	defer srv.Close()
+	srv.AddIssue(jiramock.Issue{Key: "ABC-1", Updated: t0})
+	srv.SetMyself(jiramock.User{AccountID: "acc"})
+	srv.Reset()
+
+	c := newClient(t, srv)
+	if _, err := c.Issue(context.Background(), "ABC-1"); !jira.IsNotFound(err) {
+		t.Fatalf("expected 404 after reset, got %v", err)
+	}
+	if _, err := c.Myself(context.Background()); err == nil {
+		t.Fatalf("expected 401 after reset")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+func fmtKey(proj string, n int) string {
+	return proj + "-" + itoa(n)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+func keysOf(p *jira.SearchPage) []string {
+	out := make([]string, 0, len(p.Entries))
+	for _, e := range p.Entries {
+		out = append(out, e.Issue.Key)
+	}
+	return out
+}

--- a/internal/jiramock/jql.go
+++ b/internal/jiramock/jql.go
@@ -1,0 +1,50 @@
+package jiramock
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// jqlFilter is a permissive parse of the JQL clauses this codebase emits.
+// Anything we don't recognise is silently ignored so tests stay loose.
+type jqlFilter struct {
+	project      string
+	updatedSince *time.Time
+	orderDesc    bool
+}
+
+var (
+	rxProject = regexp.MustCompile(`(?i)\bproject\s*=\s*"?([A-Z][A-Z0-9_]*)"?`)
+	rxUpdated = regexp.MustCompile(`(?i)\bupdated\s*>=\s*"([^"]+)"`)
+	rxOrder   = regexp.MustCompile(`(?i)\bORDER\s+BY\s+updated\s+(ASC|DESC)\b`)
+)
+
+func parseJQL(s string) jqlFilter {
+	f := jqlFilter{}
+	if m := rxProject.FindStringSubmatch(s); m != nil {
+		f.project = strings.ToUpper(m[1])
+	}
+	if m := rxUpdated.FindStringSubmatch(s); m != nil {
+		// Jira accepts both "2006-01-02 15:04" and ISO forms; we support
+		// the same set as the production client.
+		layouts := []string{
+			"2006-01-02 15:04",
+			"2006-01-02T15:04:05.000-0700",
+			time.RFC3339,
+			time.RFC3339Nano,
+			"2006-01-02",
+		}
+		for _, l := range layouts {
+			if t, err := time.Parse(l, m[1]); err == nil {
+				tt := t.UTC()
+				f.updatedSince = &tt
+				break
+			}
+		}
+	}
+	if m := rxOrder.FindStringSubmatch(s); m != nil {
+		f.orderDesc = strings.EqualFold(m[1], "DESC")
+	}
+	return f
+}

--- a/internal/jiramock/wire.go
+++ b/internal/jiramock/wire.go
@@ -1,0 +1,99 @@
+package jiramock
+
+// Wire structs mirror Atlassian's published OpenAPI v3 schemas at
+// https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json.
+// Only the fields we serve are modelled — Jira returns far more than
+// we need, but the JSON shape and key names match the upstream contract.
+
+type wireUser struct {
+	AccountID    string `json:"accountId"`
+	AccountType  string `json:"accountType,omitempty"`
+	Active       bool   `json:"active"`
+	DisplayName  string `json:"displayName"`
+	EmailAddress string `json:"emailAddress,omitempty"`
+	Self         string `json:"self,omitempty"`
+	TimeZone     string `json:"timeZone,omitempty"`
+}
+
+type wireNamed struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name"`
+	Self string `json:"self,omitempty"`
+}
+
+type wireProject struct {
+	ID   string `json:"id,omitempty"`
+	Key  string `json:"key"`
+	Name string `json:"name,omitempty"`
+	Self string `json:"self,omitempty"`
+}
+
+type wireStatusCategory struct {
+	ID   int    `json:"id,omitempty"`
+	Key  string `json:"key"`
+	Name string `json:"name,omitempty"`
+}
+
+type wireStatus struct {
+	ID             string             `json:"id,omitempty"`
+	Name           string             `json:"name"`
+	Self           string             `json:"self,omitempty"`
+	StatusCategory wireStatusCategory `json:"statusCategory"`
+}
+
+type wireIssueFields struct {
+	Summary     string     `json:"summary"`
+	Description any        `json:"description,omitempty"`
+	IssueType   wireNamed  `json:"issuetype"`
+	Status      wireStatus `json:"status"`
+	Priority    *wireNamed `json:"priority,omitempty"`
+	Project     wireProject `json:"project"`
+	Assignee    *wireUser  `json:"assignee"`
+	Reporter    *wireUser  `json:"reporter"`
+	Labels      []string   `json:"labels"`
+	DueDate     string     `json:"duedate,omitempty"`
+	Created     string     `json:"created"`
+	Updated     string     `json:"updated"`
+}
+
+// IssueBean (subset) — id/key/self/fields are the bits clients touch.
+type wireIssue struct {
+	Expand string          `json:"expand,omitempty"`
+	ID     string          `json:"id"`
+	Self   string          `json:"self"`
+	Key    string          `json:"key"`
+	Fields wireIssueFields `json:"fields"`
+}
+
+// SearchAndReconcileResults.
+type wireSearchPage struct {
+	Issues        []wireIssue `json:"issues"`
+	NextPageToken string      `json:"nextPageToken,omitempty"`
+	IsLast        bool        `json:"isLast"`
+}
+
+// PageOfComments.
+type wireCommentsPage struct {
+	Comments   []wireComment `json:"comments"`
+	StartAt    int           `json:"startAt"`
+	MaxResults int           `json:"maxResults"`
+	Total      int           `json:"total"`
+}
+
+type wireComment struct {
+	ID           string    `json:"id"`
+	Self         string    `json:"self,omitempty"`
+	Author       *wireUser `json:"author,omitempty"`
+	UpdateAuthor *wireUser `json:"updateAuthor,omitempty"`
+	Body         any       `json:"body"`
+	Created      string    `json:"created"`
+	Updated      string    `json:"updated"`
+	JsdPublic    bool      `json:"jsdPublic"`
+}
+
+// ErrorCollection — Jira's standard error envelope.
+type wireErrorCollection struct {
+	ErrorMessages []string          `json:"errorMessages"`
+	Errors        map[string]string `json:"errors,omitempty"`
+	Status        int               `json:"status,omitempty"`
+}


### PR DESCRIPTION
## Summary

- **Coverage tasks** (`18e4fd2`): wires `task cover` and `task cover:html` on top of Go's built-in `go test -coverprofile` + `go tool cover`. No third-party tool needed. Also extends `task clean` and `.gitignore` to handle the new artifacts. Total coverage today reads at 55.8%.
- **`internal/jiramock`** (`09b6c94`): an in-memory HTTP mock of the Atlassian Jira Cloud REST API v3, suitable for any future test that wants to talk to a real `*jira.Client` without hitting Atlassian. Response shapes mirror Atlassian's published [OpenAPI v3 schema](https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json) (`User`, `IssueBean`, `SearchAndReconcileResults`, `PageOfComments`, `Comment`).

### What jiramock gives you

- Endpoints served: `GET /rest/api/3/myself`, `/issue/{key}`, `/issue/{key}/comment`, `/search/jql`
- Builder API: `SetMyself`, `AddIssue`, `AddComment` — plain text descriptions/bodies auto-wrap in single-paragraph ADF
- Permissive JQL filter: `project = X`, `updated >= "..."`, `ORDER BY updated ASC|DESC`
- Configurable page size + opaque `nextPageToken` cursor
- `InjectFault({Path, Status, RetryAfter, Times})` for 4xx/5xx/429 retry tests
- `Requests()` returns the recorded call log

10 new tests cover both raw schema shape (top-level keys, ADF doc, `statusCategory.key`) and round-trips through a real `*jira.Client`. Package coverage: 82%.

I left `client_test.go` and `sync_test.go` alone — those test below and above the HTTP boundary respectively and the mock isn't a fit. Existing fakes can migrate incrementally.

## Test plan

- [x] `task test` (or `go test ./...`) — all packages green
- [x] `task vet` — clean
- [x] `task cover` — produces `coverage.out` and per-function summary
- [x] `task cover:html` — produces `coverage.html`
- [x] `task clean` — removes coverage artifacts
- [x] New `internal/jiramock` tests pass and exercise both raw HTTP shape and the `*jira.Client` decode path

https://claude.ai/code/session_01444ygdLByP3esrzrHncE5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01444ygdLByP3esrzrHncE5f)_