### PR TITLE
Propagate terminal size to detail view so comments render

### DIFF
--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -53,6 +53,11 @@ type Model struct {
 	detail detail.Model
 	view   View
 
+	// width/height track the most recent terminal size so views opened
+	// after startup (e.g. detail when the user drills into an issue) can
+	// inherit it and render with the correct page size.
+	width, height int
+
 	// pendingOpen, if non-empty, is the key to re-open on startup after the
 	// list's initial load completes.
 	pendingOpen string
@@ -104,6 +109,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if km, ok := msg.(tea.KeyMsg); ok && km.Type == tea.KeyCtrlC {
 		m.save()
 		return m, tea.Quit
+	}
+
+	// Remember the latest terminal size so views created later (e.g. the
+	// detail view) inherit it. The message still falls through to the
+	// active view via the routing switch below.
+	if ws, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width, m.height = ws.Width, ws.Height
 	}
 
 	switch msg := msg.(type) {
@@ -242,6 +254,9 @@ func (m Model) pushDetail(iss model.Issue) (Model, tea.Cmd) {
 		detailOpts = append(detailOpts, detail.WithClipboard(detailClipAdapter{m.clip}))
 	}
 	m.detail = detail.New(m.reader, siblings, idx, detailOpts...)
+	if m.width > 0 || m.height > 0 {
+		m.detail.SetSize(m.width, m.height)
+	}
 	m.view = ViewDetail
 	return m, m.detail.Init()
 }

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -3,6 +3,7 @@ package tui_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +128,53 @@ func TestRoot_OpenExistingIssue_PushesDetail(t *testing.T) {
 	}
 	if got := m.DetailKey(); got != "ABC-1" {
 		t.Fatalf("detail key=%q want ABC-1", got)
+	}
+}
+
+// TestRoot_OpenIssue_DisplaysPersistedComments verifies that when the user
+// opens an issue, the comments persisted for it are loaded and rendered in
+// the detail view. Window size is delivered while the list is focused (the
+// realistic startup order); the detail view must inherit that size so the
+// comments don't fall off the bottom of the visible page.
+func TestRoot_OpenIssue_DisplaysPersistedComments(t *testing.T) {
+	// A realistic issue with a multi-line description so that, without size
+	// propagation, comments would render below the default 20-line page.
+	a := model.Issue{
+		IssueRef:    model.IssueRef{Key: "ABC-1", ID: "ABC-1-id", ProjectKey: "ABC"},
+		Summary:     "alpha",
+		Description: "This is the description.\n\n## Section\n\nMore text here.\n\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6",
+		Type:        "Bug",
+		Status:      "To Do",
+		Assignee:    alice,
+		Created:     t0,
+		Updated:     t0,
+		URL:         "https://x.atlassian.net/browse/ABC-1",
+	}
+	s := seedStore(t, a)
+	if err := s.ReplaceComments(context.Background(), "ABC-1", []model.Comment{
+		{ID: "c1", IssueKey: "ABC-1", Author: alice, Body: "hello from alice", Created: t0},
+	}); err != nil {
+		t.Fatalf("seed comments: %v", err)
+	}
+
+	m := loadInto(t, newApp(t, s, &fakeFetcher{}, &fakeOpener{}))
+	// Window size delivered at startup, while list is still focused. This
+	// matches Bubble Tea's real boot behavior.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	m, cmd := m.Update(list.OpenIssueMsg{Key: "ABC-1"})
+	m = drain(m, cmd)
+
+	if m.CurrentView() != tui.ViewDetail {
+		t.Fatalf("view=%v want Detail", m.CurrentView())
+	}
+
+	v := m.View()
+	if !strings.Contains(v, "Comments (1)") {
+		t.Errorf("expected 'Comments (1)' in detail view; got:\n%s", v)
+	}
+	if !strings.Contains(v, "hello from alice") {
+		t.Errorf("expected comment body in detail view; got:\n%s", v)
 	}
 }
 


### PR DESCRIPTION
The detail view inherits its width/height only via tea.WindowSizeMsg,
which Bubble Tea delivers once at startup. Until now that message was
routed only to the currently active view (the list), so when the user
drilled into an issue the freshly-created detail.Model started with
height=0 and pageSize defaulted to 20 lines. With any non-trivial
description the Comments section fell off the bottom of the page,
making persisted comments effectively invisible.

The root model now tracks the latest terminal size and seeds the new
detail view with it inside pushDetail. Persistence and ADF rendering
were unchanged; the bug was purely in the view sizing handoff.

https://claude.ai/code/session_01RJFCtiPXdQ2vui9CxUHeuy