### PR TITLE
Improve test coverage from 55.8% to 80.7%

### DIFF
--- a/cmd/cobra_test.go
+++ b/cmd/cobra_test.go
@@ -1,0 +1,104 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/anttti/j/cmd"
+)
+
+// TestNewRootCmd_StructureAndHelp covers NewRootCmd's tree wiring: the root
+// command must register the expected subcommands so that `jira <cmd> --help`
+// works without crashing. Calling --help short-circuits before any
+// dependency is touched (no config file read, no Jira reachability).
+func TestNewRootCmd_StructureAndHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := cmd.NewRootCmd(&stdout, &stderr)
+	if root == nil {
+		t.Fatalf("NewRootCmd returned nil")
+	}
+	if root.Use != "jira" {
+		t.Fatalf("Use=%q want jira", root.Use)
+	}
+
+	wantSubs := []string{"sync", "daemon", "doctor", "agent"}
+	gotSubs := map[string]bool{}
+	for _, c := range root.Commands() {
+		gotSubs[c.Name()] = true
+	}
+	for _, name := range wantSubs {
+		if !gotSubs[name] {
+			t.Errorf("missing subcommand %q (have %v)", name, gotSubs)
+		}
+	}
+}
+
+func TestNewRootCmd_ConfigFlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd(new(bytes.Buffer), new(bytes.Buffer))
+	flag := root.PersistentFlags().Lookup("config")
+	if flag == nil {
+		t.Fatalf("--config flag missing")
+	}
+	if flag.DefValue != "" {
+		t.Fatalf("--config default=%q want empty", flag.DefValue)
+	}
+}
+
+func TestRoot_Help_PrintsUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := cmd.NewRootCmd(&stdout, &stderr)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute --help: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Terminal UI for Jira Cloud") {
+		t.Fatalf("usage output missing description:\n%s", out)
+	}
+	for _, sub := range []string{"sync", "daemon", "doctor", "agent"} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("usage missing %q in:\n%s", sub, out)
+		}
+	}
+}
+
+func TestRoot_AgentSubcommands_HaveInstallAndUninstall(t *testing.T) {
+	root := cmd.NewRootCmd(new(bytes.Buffer), new(bytes.Buffer))
+	var agentCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "agent" {
+			agentCmd = c
+			break
+		}
+	}
+	if agentCmd == nil {
+		t.Fatalf("agent subcommand not registered")
+	}
+	got := map[string]bool{}
+	for _, c := range agentCmd.Commands() {
+		got[c.Name()] = true
+	}
+	for _, name := range []string{"install", "uninstall"} {
+		if !got[name] {
+			t.Errorf("agent.%s missing", name)
+		}
+	}
+}
+
+func TestRoot_BadConfigPath_ReturnsConfigError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := cmd.NewRootCmd(&stdout, &stderr)
+	// Pointing at a non-existent file under --config skips EnsureDefault
+	// and goes straight to LoadFrom, which fails.
+	root.SetArgs([]string{"sync", "--config", "/tmp/jui-test-does-not-exist.toml"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected config error")
+	}
+	if !strings.Contains(err.Error(), "config:") {
+		t.Fatalf("error should be wrapped in 'config:'; got %v", err)
+	}
+}

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -1,0 +1,63 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anttti/j/cmd"
+)
+
+// TestDaemon_RunsSyncLoopUntilContextCancelled verifies the daemon loop
+// invokes Sync repeatedly and exits cleanly on context cancellation.
+func TestDaemon_RunsSyncLoopUntilContextCancelled(t *testing.T) {
+	fj := &fakeJira{}
+	srv := httptest.NewServer(fj.handler())
+	defer srv.Close()
+	cfg := withBaseURL(writeConfig(t, strings.TrimPrefix(srv.URL, "http://")), srv.URL)
+	cfg.SyncInterval = 10 * time.Millisecond // tight loop, but bounded
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var err error
+	go func() {
+		defer wg.Done()
+		err = cmd.Daemon(ctx, cfg, &buf)
+	}()
+	// Let it run a couple of cycles, then cancel.
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+	wg.Wait()
+	if err != nil && err != context.Canceled {
+		t.Fatalf("Daemon: %v", err)
+	}
+	// At least one sync should have completed.
+	if !strings.Contains(buf.String(), "sync: ok") {
+		t.Fatalf("expected at least one 'sync: ok' line:\n%s", buf.String())
+	}
+}
+
+func TestDaemon_PrintsErrorOnSyncFailure(t *testing.T) {
+	// Server that always 500s on /search/jql so Sync returns an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	cfg := withBaseURL(writeConfig(t, "x"), srv.URL)
+	cfg.SyncInterval = 5 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	var buf bytes.Buffer
+	_ = cmd.Daemon(ctx, cfg, &buf)
+	if !strings.Contains(buf.String(), "sync error:") {
+		t.Fatalf("expected 'sync error:' line:\n%s", buf.String())
+	}
+}

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -1,0 +1,196 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anttti/j/internal/config"
+)
+
+func TestEnsureDefault_WritesFileWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "jui.toml")
+	created, err := config.EnsureDefault(path)
+	if err != nil {
+		t.Fatalf("EnsureDefault: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true on first call")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file not written: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "site = ") {
+		t.Fatalf("default body missing site key:\n%s", string(body))
+	}
+}
+
+func TestEnsureDefault_DoesNotOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jui.toml")
+	if err := os.WriteFile(path, []byte("# user content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	created, err := config.EnsureDefault(path)
+	if err != nil {
+		t.Fatalf("EnsureDefault: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created=false when file exists")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "# user content" {
+		t.Fatalf("file overwritten unexpectedly:\n%s", string(body))
+	}
+}
+
+func TestDefaultPath_PointsUnderHome(t *testing.T) {
+	got := config.DefaultPath()
+	home, _ := os.UserHomeDir()
+	if home != "" && !strings.HasPrefix(got, home) {
+		t.Fatalf("DefaultPath()=%q should start with %q", got, home)
+	}
+	if !strings.HasSuffix(got, "jui.toml") {
+		t.Fatalf("DefaultPath()=%q should end in jui.toml", got)
+	}
+}
+
+func TestParseDuration_RejectsBadDayValue(t *testing.T) {
+	if _, err := config.ParseDuration("xd"); err == nil {
+		t.Fatalf("expected error for 'xd'")
+	}
+}
+
+func TestParseDuration_ZeroDays(t *testing.T) {
+	d, err := config.ParseDuration("0d")
+	if err != nil {
+		t.Fatalf("ParseDuration: %v", err)
+	}
+	if d != 0 {
+		t.Fatalf("0d -> %v", d)
+	}
+}
+
+func TestParseDuration_HourMinuteVariants(t *testing.T) {
+	for input, want := range map[string]time.Duration{
+		"1h":    time.Hour,
+		"30m":   30 * time.Minute,
+		"1h30m": 90 * time.Minute,
+	} {
+		got, err := config.ParseDuration(input)
+		if err != nil {
+			t.Fatalf("ParseDuration(%q): %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("ParseDuration(%q)=%v want %v", input, got, want)
+		}
+	}
+}
+
+func TestLoadFrom_RejectsBadDuration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+site = "x.atlassian.net"
+email = "e@x"
+api_token = "tok"
+sync_interval = "5banana"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatalf("expected error on bad sync_interval")
+	}
+	if !strings.Contains(err.Error(), "sync_interval") {
+		t.Fatalf("error should mention sync_interval; got %v", err)
+	}
+}
+
+func TestLoadFrom_RejectsBadInitialLookback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+site = "x.atlassian.net"
+email = "e@x"
+api_token = "tok"
+initial_lookback = "12bogus"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatalf("expected error on bad initial_lookback")
+	}
+	if !strings.Contains(err.Error(), "initial_lookback") {
+		t.Fatalf("error should mention initial_lookback; got %v", err)
+	}
+}
+
+func TestLoadFrom_MissingFileError(t *testing.T) {
+	_, err := config.LoadFrom(filepath.Join(t.TempDir(), "missing.toml"))
+	if err == nil {
+		t.Fatalf("expected error reading missing file")
+	}
+}
+
+func TestLoad_UsesDefaultPathAndCreatesFile(t *testing.T) {
+	// Setting HOME to a tempdir reroutes config.DefaultPath() under it so
+	// Load() exercises EnsureDefault + LoadFrom end-to-end without
+	// touching the real user config.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// First call: file is created. Default body is missing required fields,
+	// so Load returns an error — but a meaningful one ("missing required").
+	_, err := config.Load()
+	if err == nil {
+		t.Fatalf("expected missing-fields error from default body")
+	}
+	if !strings.Contains(err.Error(), "missing required") {
+		t.Fatalf("error should mention missing fields; got %v", err)
+	}
+
+	// Verify the default file landed where DefaultPath() points.
+	if _, statErr := os.Stat(config.DefaultPath()); statErr != nil {
+		t.Fatalf("DefaultPath file not created: %v", statErr)
+	}
+}
+
+func TestLoad_DerivesPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jui.toml")
+	body := `
+site = "x.atlassian.net"
+email = "e@x"
+api_token = "tok"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.ConfigDir != dir {
+		t.Fatalf("ConfigDir=%q want %q", cfg.ConfigDir, dir)
+	}
+	if cfg.DBPath != filepath.Join(dir, "jira.db") {
+		t.Fatalf("DBPath=%q", cfg.DBPath)
+	}
+	if cfg.BaseURL != "https://x.atlassian.net" {
+		t.Fatalf("BaseURL=%q", cfg.BaseURL)
+	}
+}

--- a/internal/jira/adf_test.go
+++ b/internal/jira/adf_test.go
@@ -1,0 +1,233 @@
+package jira
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderADF_TextWithLink(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"text","text":"see ","marks":[]},
+				{"type":"text","text":"docs","marks":[{"type":"link","attrs":{"href":"https://example.com"}}]}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	out := renderADF(n)
+	want := "see [docs](https://example.com)"
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected %q in:\n%q", want, out)
+	}
+}
+
+func TestRenderADF_LinkWithEmptyHrefRendersBareText(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"text","text":"orphan","marks":[{"type":"link","attrs":{}}]}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	out := renderADF(n)
+	if strings.Contains(out, "[orphan]") {
+		t.Fatalf("link with empty href should render as plain text; got %q", out)
+	}
+	if !strings.Contains(out, "orphan") {
+		t.Fatalf("text missing from output: %q", out)
+	}
+}
+
+func TestRenderADF_MentionUsesAttrText(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"mention","attrs":{"text":"@Alice"}}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	if got := renderADF(n); !strings.Contains(got, "@Alice") {
+		t.Fatalf("expected '@Alice' in:\n%q", got)
+	}
+}
+
+func TestRenderADF_MentionFallsBackToTextField(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"mention","text":"Bob"}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	if got := renderADF(n); !strings.Contains(got, "@Bob") {
+		t.Fatalf("expected '@Bob' fallback, got %q", got)
+	}
+}
+
+func TestRenderADF_AllInlineMarks(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"text","text":"a","marks":[{"type":"strong"}]},
+				{"type":"text","text":"b","marks":[{"type":"em"}]},
+				{"type":"text","text":"c","marks":[{"type":"strike"}]},
+				{"type":"text","text":"d","marks":[{"type":"code"}]}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	out := renderADF(n)
+	for _, want := range []string{"**a**", "*b*", "~~c~~", "`d`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%q", want, out)
+		}
+	}
+}
+
+func TestRenderADF_HeadingLevelsClampToValidRange(t *testing.T) {
+	cases := []struct {
+		level int
+		want  string
+	}{
+		{0, "# "},   // clamps up to 1
+		{1, "# "},
+		{6, "###### "},
+		{9, "###### "}, // clamps down to 6
+	}
+	for _, tc := range cases {
+		body := `{"type":"doc","content":[{"type":"heading","attrs":{"level":` + itoa(tc.level) + `},"content":[{"type":"text","text":"Title"}]}]}`
+		var n adfNode
+		if err := json.Unmarshal([]byte(body), &n); err != nil {
+			t.Fatal(err)
+		}
+		got := renderADF(n)
+		if !strings.HasPrefix(got, tc.want) {
+			t.Fatalf("level=%d expected prefix %q in %q", tc.level, tc.want, got)
+		}
+	}
+}
+
+func TestRenderADF_OrderedAndBulletLists(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"orderedList","content":[
+				{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first"}]}]},
+				{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"second"}]}]}
+			]},
+			{"type":"bulletList","content":[
+				{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"alpha"}]}]}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	out := renderADF(n)
+	for _, want := range []string{"1. first", "1. second", "- alpha"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%q", want, out)
+		}
+	}
+}
+
+func TestRenderADF_CodeBlockFenced(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"codeBlock","content":[{"type":"text","text":"go test ./..."}]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	out := renderADF(n)
+	if !strings.Contains(out, "```\ngo test ./...\n```") {
+		t.Fatalf("codeBlock not fenced as expected: %q", out)
+	}
+}
+
+func TestRenderADF_HardBreakInsertsTwoSpacesNewline(t *testing.T) {
+	body := `{
+		"type":"doc",
+		"content":[
+			{"type":"paragraph","content":[
+				{"type":"text","text":"line1"},
+				{"type":"hardBreak"},
+				{"type":"text","text":"line2"}
+			]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	if got := renderADF(n); !strings.Contains(got, "line1  \nline2") {
+		t.Fatalf("hardBreak not rendered as '  \\n': %q", got)
+	}
+}
+
+func TestRenderADF_UnknownNodeFallsThroughToChildren(t *testing.T) {
+	body := `{
+		"type":"unknownContainer",
+		"content":[
+			{"type":"paragraph","content":[{"type":"text","text":"survives"}]}
+		]
+	}`
+	var n adfNode
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		t.Fatal(err)
+	}
+	if got := renderADF(n); !strings.Contains(got, "survives") {
+		t.Fatalf("unknown node should still render children, got %q", got)
+	}
+}
+
+// itoa is local to this test file (package jira already imports strconv via
+// other source files, but reaching for it here for a single 1-byte constant
+// would be overkill).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	buf := []byte{}
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	if neg {
+		buf = append([]byte{'-'}, buf...)
+	}
+	return string(buf)
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -3,19 +3,50 @@
 package platform
 
 import (
+	"io"
 	"os/exec"
 	"strings"
 )
 
-// Opener launches URLs in the user's browser via `open`.
-type Opener struct{}
+// commandRunner abstracts the exec layer so tests can swap it for a fake.
+// findFn checks if cmd is available; runFn executes it with stdin (which may
+// be nil) and returns the run error.
+type commandRunner struct {
+	findFn func(name string) error
+	runFn  func(name string, args []string, stdin io.Reader) error
+}
+
+// defaultRunner uses os/exec (the production path).
+var defaultRunner = commandRunner{
+	findFn: func(name string) error { _, err := exec.LookPath(name); return err },
+	runFn: func(name string, args []string, stdin io.Reader) error {
+		c := exec.Command(name, args...)
+		if stdin != nil {
+			c.Stdin = stdin
+		}
+		// Browser launches don't need to wait; clipboard does.
+		// We rely on the caller selecting the right behaviour by passing nil
+		// stdin for fire-and-forget (Open).
+		if stdin == nil {
+			return c.Start()
+		}
+		return c.Run()
+	},
+}
+
+// Opener launches URLs in the user's browser via `open` / `xdg-open`.
+type Opener struct{ runner commandRunner }
 
 // Open invokes `open <url>` (macOS). Falls back to xdg-open on Linux so
 // the binary is still usable for development.
-func (Opener) Open(url string) error {
+func (o Opener) Open(url string) error {
+	r := o.runner
+	if r.findFn == nil {
+		r = defaultRunner
+	}
 	for _, cmd := range []string{"open", "xdg-open"} {
-		if _, err := exec.LookPath(cmd); err == nil {
-			return exec.Command(cmd, url).Start()
+		if err := r.findFn(cmd); err == nil {
+			return r.runFn(cmd, []string{url}, nil)
 		}
 	}
 	return nil
@@ -23,20 +54,22 @@ func (Opener) Open(url string) error {
 
 // Clipboard copies text via `pbcopy` on macOS (falls back to xclip/wl-copy
 // when available).
-type Clipboard struct{}
+type Clipboard struct{ runner commandRunner }
 
 // Copy writes s to the OS clipboard.
-func (Clipboard) Copy(s string) error {
+func (c Clipboard) Copy(s string) error {
+	r := c.runner
+	if r.findFn == nil {
+		r = defaultRunner
+	}
 	candidates := [][]string{
 		{"pbcopy"},
 		{"wl-copy"},
 		{"xclip", "-selection", "clipboard"},
 	}
 	for _, cc := range candidates {
-		if _, err := exec.LookPath(cc[0]); err == nil {
-			c := exec.Command(cc[0], cc[1:]...)
-			c.Stdin = strings.NewReader(s)
-			return c.Run()
+		if err := r.findFn(cc[0]); err == nil {
+			return r.runFn(cc[0], cc[1:], strings.NewReader(s))
 		}
 	}
 	return nil

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,182 @@
+package platform
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records find/run calls and lets each test pin which commands
+// are "available" (LookPath ok) and what runFn should return.
+type fakeRunner struct {
+	available map[string]bool
+	runErr    error
+
+	findCalls []string
+	runCalls  []runCall
+}
+
+type runCall struct {
+	name  string
+	args  []string
+	stdin string
+}
+
+func (f *fakeRunner) lookup() (func(string) error, func(string, []string, io.Reader) error) {
+	return func(name string) error {
+			f.findCalls = append(f.findCalls, name)
+			if f.available[name] {
+				return nil
+			}
+			return errors.New("not found: " + name)
+		}, func(name string, args []string, stdin io.Reader) error {
+			rc := runCall{name: name, args: append([]string(nil), args...)}
+			if stdin != nil {
+				b, _ := io.ReadAll(stdin)
+				rc.stdin = string(b)
+			}
+			f.runCalls = append(f.runCalls, rc)
+			return f.runErr
+		}
+}
+
+func newOpener(f *fakeRunner) Opener {
+	find, run := f.lookup()
+	return Opener{runner: commandRunner{findFn: find, runFn: run}}
+}
+
+func newClipboard(f *fakeRunner) Clipboard {
+	find, run := f.lookup()
+	return Clipboard{runner: commandRunner{findFn: find, runFn: run}}
+}
+
+// -----------------------------------------------------------------------------
+// Opener
+// -----------------------------------------------------------------------------
+
+func TestOpener_PrefersOpenOverXdgOpen(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"open": true, "xdg-open": true}}
+	if err := newOpener(f).Open("https://example.com"); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(f.runCalls) != 1 || f.runCalls[0].name != "open" {
+		t.Fatalf("expected single 'open' call; got %+v", f.runCalls)
+	}
+	if f.runCalls[0].args[0] != "https://example.com" {
+		t.Fatalf("url not passed: %+v", f.runCalls[0])
+	}
+}
+
+func TestOpener_FallsBackToXdgOpen(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"xdg-open": true}}
+	if err := newOpener(f).Open("https://example.com"); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(f.runCalls) != 1 || f.runCalls[0].name != "xdg-open" {
+		t.Fatalf("expected fallback to 'xdg-open'; got %+v", f.runCalls)
+	}
+}
+
+func TestOpener_NoCommandsAvailable_NoOp(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{}}
+	if err := newOpener(f).Open("https://example.com"); err != nil {
+		t.Fatalf("Open should not error when nothing's available: %v", err)
+	}
+	if len(f.runCalls) != 0 {
+		t.Fatalf("expected no run calls, got %+v", f.runCalls)
+	}
+}
+
+func TestOpener_PropagatesRunError(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"open": true}, runErr: errors.New("nope")}
+	if err := newOpener(f).Open("u"); err == nil {
+		t.Fatalf("expected error from run")
+	}
+}
+
+func TestOpener_DefaultRunnerIsUsedIfUnset(t *testing.T) {
+	// Calling the zero-value opener should fall through to the default
+	// runner without panicking. Whatever happens to be on PATH might run;
+	// we just assert no panic and no error returned for the no-PATH case.
+	o := Opener{}
+	// Use a URL likely to be benign even if a command did run.
+	_ = o.Open("about:blank")
+}
+
+// -----------------------------------------------------------------------------
+// Clipboard
+// -----------------------------------------------------------------------------
+
+func TestClipboard_PrefersPbcopy(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"pbcopy": true, "wl-copy": true, "xclip": true}}
+	if err := newClipboard(f).Copy("hello"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(f.runCalls) != 1 || f.runCalls[0].name != "pbcopy" {
+		t.Fatalf("expected pbcopy; got %+v", f.runCalls)
+	}
+	if f.runCalls[0].stdin != "hello" {
+		t.Fatalf("stdin: got %q want hello", f.runCalls[0].stdin)
+	}
+}
+
+func TestClipboard_FallsBackToWlCopy(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"wl-copy": true, "xclip": true}}
+	if err := newClipboard(f).Copy("hi"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(f.runCalls) != 1 || f.runCalls[0].name != "wl-copy" {
+		t.Fatalf("expected wl-copy fallback; got %+v", f.runCalls)
+	}
+}
+
+func TestClipboard_FallsBackToXclipWithSelectionArg(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{"xclip": true}}
+	if err := newClipboard(f).Copy("ABC-1"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(f.runCalls) != 1 || f.runCalls[0].name != "xclip" {
+		t.Fatalf("expected xclip fallback; got %+v", f.runCalls)
+	}
+	wantArgs := []string{"-selection", "clipboard"}
+	if !equalSS(f.runCalls[0].args, wantArgs) {
+		t.Fatalf("xclip args=%v want %v", f.runCalls[0].args, wantArgs)
+	}
+	if f.runCalls[0].stdin != "ABC-1" {
+		t.Fatalf("stdin: %q", f.runCalls[0].stdin)
+	}
+}
+
+func TestClipboard_NoCommandsAvailable_NoOp(t *testing.T) {
+	f := &fakeRunner{available: map[string]bool{}}
+	if err := newClipboard(f).Copy("anything"); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(f.runCalls) != 0 {
+		t.Fatalf("expected no run calls; got %+v", f.runCalls)
+	}
+}
+
+func TestClipboard_PropagatesRunError(t *testing.T) {
+	f := &fakeRunner{
+		available: map[string]bool{"pbcopy": true},
+		runErr:    errors.New("disk full"),
+	}
+	err := newClipboard(f).Copy("x")
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("expected wrapped error, got %v", err)
+	}
+}
+
+func equalSS(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/storetest/storetest_test.go
+++ b/internal/store/storetest/storetest_test.go
@@ -1,0 +1,19 @@
+package storetest_test
+
+import (
+	"testing"
+
+	"github.com/anttti/j/internal/store"
+	"github.com/anttti/j/internal/store/memstore"
+	"github.com/anttti/j/internal/store/storetest"
+)
+
+// TestRun_DriveSuiteAgainstMemstore exercises every helper inside the
+// storetest package itself. The suite is already used by memstore and
+// sqlitestore via their own *_test.go files, but those measure coverage
+// on a per-package basis so this package would otherwise show 0%.
+func TestRun_DriveSuiteAgainstMemstore(t *testing.T) {
+	storetest.Run(t, func(t *testing.T) store.Store {
+		return memstore.New()
+	})
+}

--- a/internal/tui/detail/detail_extra_test.go
+++ b/internal/tui/detail/detail_extra_test.go
@@ -1,0 +1,118 @@
+package detail_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/anttti/j/internal/model"
+	"github.com/anttti/j/internal/tui/detail"
+)
+
+// Tests for the less-traveled key bindings on detail.Model: arrow keys,
+// half-page scrolling (Ctrl+D / Ctrl+U), the [ clamp at index 0, and the
+// W (open-in-browser) alias.
+
+func TestDetail_ArrowKeys_ScrollByOne(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	m := loadInto(t, detail.New(seedStore(t, a), []model.Issue{a}, 0))
+	m.SetSize(80, 8) // small window so MaxScroll>0
+	m = press(t, m, special(tea.KeyDown))
+	if m.Scroll() != 1 {
+		t.Fatalf("Down: scroll=%d", m.Scroll())
+	}
+	m = press(t, m, special(tea.KeyUp))
+	if m.Scroll() != 0 {
+		t.Fatalf("Up: scroll=%d", m.Scroll())
+	}
+	m = press(t, m, special(tea.KeyUp))
+	if m.Scroll() != 0 {
+		t.Fatalf("Up clamp: scroll=%d", m.Scroll())
+	}
+}
+
+func TestDetail_CtrlDAndCtrlU_HalfPageScroll(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	m := loadInto(t, detail.New(seedStore(t, a), []model.Issue{a}, 0))
+	m.SetSize(80, 8)
+	max := m.MaxScroll()
+	m = press(t, m, special(tea.KeyCtrlD))
+	if m.Scroll() == 0 {
+		t.Fatalf("Ctrl+D should advance scroll, got 0 (max=%d)", max)
+	}
+	pos := m.Scroll()
+	m = press(t, m, special(tea.KeyCtrlU))
+	if m.Scroll() >= pos {
+		t.Fatalf("Ctrl+U should reduce scroll: %d -> %d", pos, m.Scroll())
+	}
+}
+
+func TestDetail_LeftBracket_ClampsAtZero(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	b := mkIssue("ABC-2", "beta", time.Hour)
+	m := loadInto(t, detail.New(seedStore(t, a, b), []model.Issue{a, b}, 0))
+	m = press(t, m, key('['))
+	if m.Current().Key != "ABC-1" {
+		t.Fatalf("[ at idx 0 should be no-op; got %q", m.Current().Key)
+	}
+}
+
+func TestDetail_W_AliasForO(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	m := loadInto(t, detail.New(seedStore(t, a), []model.Issue{a}, 0))
+	_, cmd := m.Update(key('w'))
+	if cmd == nil {
+		t.Fatalf("expected cmd")
+	}
+	if _, ok := cmd().(detail.OpenURLMsg); !ok {
+		t.Fatalf("expected OpenURLMsg")
+	}
+}
+
+func TestDetail_New_NegativeIndexClampsToZero(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	m := detail.New(seedStore(t, a), []model.Issue{a}, -3)
+	if m.Current().Key != "ABC-1" {
+		t.Fatalf("negative idx should clamp to 0; got %q", m.Current().Key)
+	}
+}
+
+func TestDetail_New_OutOfRangeClampsToLast(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	b := mkIssue("ABC-2", "beta", time.Hour)
+	m := detail.New(seedStore(t, a, b), []model.Issue{a, b}, 99)
+	if m.Current().Key != "ABC-2" {
+		t.Fatalf("oob idx should clamp to last; got %q", m.Current().Key)
+	}
+}
+
+func TestDetail_WindowSize_PersistsAndAffectsPageSize(t *testing.T) {
+	a := mkIssue("ABC-1", "alpha", 0)
+	m := loadInto(t, detail.New(seedStore(t, a), []model.Issue{a}, 0))
+	// Tall viewport: MaxScroll trends towards 0 because all content fits.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 1000})
+	if next.MaxScroll() != 0 {
+		t.Fatalf("with huge height, MaxScroll should be 0; got %d", next.MaxScroll())
+	}
+}
+
+func TestDetail_CommentsForOtherIssue_AreIgnored(t *testing.T) {
+	// loadCommentsCmd is keyed by issue Key. If we receive a stale message
+	// targeting a different issue, it should not overwrite current state.
+	a := mkIssue("ABC-1", "alpha", 0)
+	b := mkIssue("ABC-2", "beta", time.Hour)
+	s := seedStore(t, a, b)
+	_ = s.ReplaceComments(context.Background(), "ABC-1",
+		[]model.Comment{{ID: "c1", IssueKey: "ABC-1", Body: "for a", Created: t0}})
+	m := loadInto(t, detail.New(s, []model.Issue{a, b}, 0))
+	if got := len(m.Comments()); got != 1 {
+		t.Fatalf("precondition: comments=%d", got)
+	}
+	// Move to ABC-2 — its comments load + replace state.
+	m = press(t, m, key(']'))
+	if got := len(m.Comments()); got != 0 {
+		t.Fatalf("comments for ABC-2 should be empty; got %d", got)
+	}
+}

--- a/internal/tui/list/helpers_internal_test.go
+++ b/internal/tui/list/helpers_internal_test.go
@@ -1,0 +1,278 @@
+package list
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anttti/j/internal/model"
+)
+
+// These are internal tests for the unexported helpers in list.go. They
+// would otherwise stay 0% — the public Update flow rarely takes the rare
+// branches (large windows, distant timestamps, malformed issue keys).
+
+func TestRelTime_FormatsRanges(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"zero", time.Time{}, "—"},
+		{"now", now, "now"},
+		{"few seconds ago is still 'now'", now.Add(-5 * time.Second), "now"},
+		{"5 minutes", now.Add(-5 * time.Minute), "5m"},
+		{"3 hours", now.Add(-3 * time.Hour), "3h"},
+		{"3 days", now.Add(-3 * 24 * time.Hour), "3d"},
+		{"2 weeks", now.Add(-15 * 24 * time.Hour), "2w"},
+		{"2 years", now.Add(-2 * 365 * 24 * time.Hour), "2y"},
+		// Future stamps fold to absolute durations.
+		{"future 5m", now.Add(5*time.Minute + time.Second), "5m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relTime(tc.t); got != tc.want {
+				t.Fatalf("relTime: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeIssueKey(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"ABC-1", true},
+		{"abc-1", true},
+		{"AB12-99", true},
+		{"ABC-", false},
+		{"-1", false},
+		{"ABC", false},
+		{"ABC-12X", false},
+		{"AB!C-1", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeIssueKey(tc.in); got != tc.want {
+			t.Errorf("looksLikeIssueKey(%q)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHalfPage_DefaultsAndMath(t *testing.T) {
+	if got := halfPage(0); got != 10 {
+		t.Fatalf("halfPage(0)=%d want default 10", got)
+	}
+	// (h-6)/2
+	if got := halfPage(26); got != 10 {
+		t.Fatalf("halfPage(26)=%d want 10", got)
+	}
+	if got := halfPage(20); got != 7 {
+		t.Fatalf("halfPage(20)=%d want 7", got)
+	}
+}
+
+func TestPageSize_DefaultsAndMath(t *testing.T) {
+	if got := pageSize(0); got != 20 {
+		t.Fatalf("pageSize(0)=%d want default 20", got)
+	}
+	if got := pageSize(30); got != 24 {
+		t.Fatalf("pageSize(30)=%d want 24", got)
+	}
+}
+
+func TestClamp(t *testing.T) {
+	cases := []struct {
+		v, lo, hi, want int
+	}{
+		{5, 0, 10, 5},
+		{-1, 0, 10, 0},
+		{15, 0, 10, 10},
+		{5, 10, 0, 10}, // hi<lo: return lo
+	}
+	for _, c := range cases {
+		if got := clamp(c.v, c.lo, c.hi); got != c.want {
+			t.Errorf("clamp(%d,%d,%d)=%d want %d", c.v, c.lo, c.hi, got, c.want)
+		}
+	}
+}
+
+func TestMaxInt(t *testing.T) {
+	if maxInt(2, 3) != 3 {
+		t.Fatal("maxInt(2,3) want 3")
+	}
+	if maxInt(7, -1) != 7 {
+		t.Fatal("maxInt(7,-1) want 7")
+	}
+}
+
+func TestSummariseSelected(t *testing.T) {
+	if got := summariseSelected(map[string]bool{}); got != "All" {
+		t.Fatalf("empty -> %q want All", got)
+	}
+	one := summariseSelected(map[string]bool{"Bug": true})
+	if one != "Bug" {
+		t.Fatalf("single -> %q", one)
+	}
+	two := summariseSelected(map[string]bool{"Bug": true, "Task": true})
+	if two != "Bug, Task" {
+		t.Fatalf("two -> %q", two)
+	}
+	many := summariseSelected(map[string]bool{"Bug": true, "Task": true, "Story": true, "Epic": true})
+	// >2 truncates to "first, +N".
+	if got := many; got == "" || got[len(got)-3:] != " +3" {
+		t.Fatalf("many -> %q want '<first>, +3'", got)
+	}
+	// keys with false values are filtered.
+	if got := summariseSelected(map[string]bool{"Bug": false}); got != "All" {
+		t.Fatalf("false-valued key should be ignored, got %q", got)
+	}
+}
+
+func TestSummariseSort(t *testing.T) {
+	if got := summariseSort(nil); got != "none" {
+		t.Fatalf("empty sort = %q want 'none'", got)
+	}
+	if got := summariseSort([]SortKey{{Column: ColKey, Desc: false}}); !endsWith(got, "↑") {
+		t.Fatalf("asc should end in ↑: %q", got)
+	}
+	if got := summariseSort([]SortKey{{Column: ColKey, Desc: true}}); !endsWith(got, "↓") {
+		t.Fatalf("desc should end in ↓: %q", got)
+	}
+	multi := summariseSort([]SortKey{
+		{Column: ColPrio, Desc: false},
+		{Column: ColUpdated, Desc: true},
+	})
+	if multi == "" {
+		t.Fatalf("multi should not be empty")
+	}
+	// Multi formatted with ", " separator.
+	if !contains(multi, ", ") {
+		t.Fatalf("expected ', ' separator in multi: %q", multi)
+	}
+}
+
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSummariseCols(t *testing.T) {
+	cols := []ColumnID{ColKey, ColSummary}
+	if got := summariseCols(cols, 0); got != "2" {
+		t.Fatalf("no preset: got %q want '2'", got)
+	}
+	if got := summariseCols(cols, 4); got != "preset 4 (2)" {
+		t.Fatalf("with preset: got %q", got)
+	}
+}
+
+func TestAssigneeLabel(t *testing.T) {
+	cases := []struct {
+		f    model.AssigneeFilter
+		want string
+	}{
+		{model.AssigneeAll(), "All"},
+		{model.AssigneeMe(), "Me"},
+		{model.AssigneeUnassigned(), "Unassigned"},
+		{model.AssigneeAccount(""), "All"},
+		{model.AssigneeAccount("acc-42"), "acc-42"},
+	}
+	for _, c := range cases {
+		if got := assigneeLabel(c.f); got != c.want {
+			t.Errorf("assigneeLabel(%+v)=%q want %q", c.f, got, c.want)
+		}
+	}
+}
+
+func TestKeysTrue_FiltersFalseValues(t *testing.T) {
+	in := map[string]bool{"a": true, "b": false, "c": true}
+	got := keysTrue(in)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2 (%v)", len(got), got)
+	}
+	for _, k := range got {
+		if k != "a" && k != "c" {
+			t.Errorf("unexpected key %q", k)
+		}
+	}
+}
+
+func TestContainsCol(t *testing.T) {
+	cols := []ColumnID{ColKey, ColStatus}
+	if !containsCol(cols, ColKey) {
+		t.Fatal("expected true for present column")
+	}
+	if containsCol(cols, ColAssignee) {
+		t.Fatal("expected false for absent column")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// columns.go internal helpers
+// -----------------------------------------------------------------------------
+
+func TestTruncateEllipsis(t *testing.T) {
+	cases := []struct {
+		in   string
+		w    int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hell…"},
+		{"hi", 0, ""},
+		{"hi", -1, ""},
+		{"hi", 1, "…"},
+	}
+	for _, c := range cases {
+		if got := truncateEllipsis(c.in, c.w); got != c.want {
+			t.Errorf("truncateEllipsis(%q, %d) = %q want %q", c.in, c.w, got, c.want)
+		}
+	}
+}
+
+func TestComputeColumnWidths_FlexAbsorbsRemainder(t *testing.T) {
+	cols := []ColumnID{ColKey, ColSummary, ColUpdated}
+	widths := computeColumnWidths(cols, 50)
+	if len(widths) != 3 {
+		t.Fatalf("widths=%v", widths)
+	}
+	// KEY=10, UPD=6, summary is the flex column → fills remainder.
+	if widths[0] != 10 || widths[2] != 6 {
+		t.Fatalf("fixed widths off: %v", widths)
+	}
+	// 50 - (10 + 6) - 2 (separators between 3 cols) = 32
+	if widths[1] != 32 {
+		t.Fatalf("flex width: %d want 32 (widths=%v)", widths[1], widths)
+	}
+}
+
+func TestComputeColumnWidths_FlexClampsToZero(t *testing.T) {
+	cols := []ColumnID{ColKey, ColSummary, ColUpdated}
+	widths := computeColumnWidths(cols, 5) // way too narrow
+	if widths[1] != 0 {
+		t.Fatalf("flex should clamp to 0 when negative; got %v", widths)
+	}
+}
+
+func TestColumnDef_UnknownReturnsKey(t *testing.T) {
+	cd := columnDef("not-a-column")
+	if cd.id != ColKey {
+		t.Fatalf("unknown column id should fall back to ColKey, got %v", cd.id)
+	}
+}
+
+func TestColumnLabel(t *testing.T) {
+	if got := columnLabel(ColKey); got != "KEY" {
+		t.Fatalf("columnLabel(ColKey)=%q want KEY", got)
+	}
+}

--- a/internal/tui/list/sort_test.go
+++ b/internal/tui/list/sort_test.go
@@ -1,0 +1,185 @@
+package list_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anttti/j/internal/model"
+	"github.com/anttti/j/internal/store/memstore"
+	"github.com/anttti/j/internal/tui/list"
+)
+
+// sortBy seeds a memstore with the issues, opens a list.Model with the given
+// sort key(s) preloaded, and returns the sorted Issues() slice. This drives
+// applySort + compareByColumn through the only path the package exposes.
+func sortBy(t *testing.T, issues []model.Issue, keys ...list.SortKey) []model.Issue {
+	t.Helper()
+	s := memstore.New()
+	for _, iss := range issues {
+		if err := s.UpsertIssue(context.Background(), iss, nil); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	m := list.New(s, list.WithInitialState(nil, keys, nil, 0, model.Filter{}))
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected initial reload cmd")
+	}
+	next, _ := m.Update(cmd())
+	return next.Issues()
+}
+
+func mkSortIssue(key, typ, status, prio, summary string, asg *model.User, created, updated time.Time) model.Issue {
+	return model.Issue{
+		IssueRef: model.IssueRef{Key: key, ID: key + "-id", ProjectKey: "ABC"},
+		Summary:  summary,
+		Type:     typ,
+		Status:   status,
+		Priority: prio,
+		Assignee: asg,
+		Created:  created,
+		Updated:  updated,
+	}
+}
+
+// applySort is an internal helper, but we exercise it through the public
+// list.Model — sort goes through Update on a loaded model. This indirectly
+// covers compareByColumn, cmpString, cmpInt, priorityRank, assigneeName.
+func TestSort_ByPriority_ranksHighestFirstWhenAscending(t *testing.T) {
+	now := time.Now()
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "Medium", "summary", nil, now, now)
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "Highest", "summary", nil, now, now)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "Low", "summary", nil, now, now)
+	d := mkSortIssue("ABC-4", "Bug", "To Do", "", "summary", nil, now, now)
+
+	got := sortBy(t, []model.Issue{a, b, c, d}, list.SortKey{Column: list.ColPrio, Desc: false})
+	wantOrder := []string{"ABC-2", "ABC-1", "ABC-3", "ABC-4"} // Highest, Medium, Low, blank
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("sort by prio asc: pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_ByPriority_descReversesOrder(t *testing.T) {
+	now := time.Now()
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "Medium", "x", nil, now, now)
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "Highest", "x", nil, now, now)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "Low", "x", nil, now, now)
+
+	got := sortBy(t, []model.Issue{a, b, c}, list.SortKey{Column: list.ColPrio, Desc: true})
+	wantOrder := []string{"ABC-3", "ABC-1", "ABC-2"}
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("sort by prio desc: pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_ByAssignee_caseInsensitive(t *testing.T) {
+	now := time.Now()
+	bob := &model.User{AccountID: "acc-bob", DisplayName: "bob"}
+	alice := &model.User{AccountID: "acc-alice", DisplayName: "Alice"}
+	carol := &model.User{AccountID: "acc-carol", DisplayName: "carol"}
+
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "", "x", bob, now, now)
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "", "x", alice, now, now)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "", "x", carol, now, now)
+	d := mkSortIssue("ABC-4", "Bug", "To Do", "", "x", nil, now, now) // unassigned → ""
+
+	got := sortBy(t, []model.Issue{a, b, c, d}, list.SortKey{Column: list.ColAssignee, Desc: false})
+	// blank ("") sorts first; then Alice, bob, carol — case-insensitive.
+	wantOrder := []string{"ABC-4", "ABC-2", "ABC-1", "ABC-3"}
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("sort by assignee asc: pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_ByCreated_ascending(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "", "x", nil, t0.Add(2*time.Hour), t0)
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "", "x", nil, t0, t0)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "", "x", nil, t0.Add(time.Hour), t0)
+
+	got := sortBy(t, []model.Issue{a, b, c}, list.SortKey{Column: list.ColCreated, Desc: false})
+	wantOrder := []string{"ABC-2", "ABC-3", "ABC-1"}
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("sort by created asc: pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_ByCreated_equalCreatedPreservesUpstreamOrder(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Equal Created times → applySort is stable, so the upstream order
+	// (memstore.List sorts by Updated desc) survives. ABC-B has the
+	// later Updated, so it should remain first after sort-by-Created.
+	a := mkSortIssue("ABC-A", "Bug", "To Do", "", "x", nil, t0, t0)
+	b := mkSortIssue("ABC-B", "Bug", "To Do", "", "x", nil, t0, t0.Add(time.Hour))
+	got := sortBy(t, []model.Issue{a, b}, list.SortKey{Column: list.ColCreated, Desc: false})
+	if got[0].Key != "ABC-B" {
+		t.Fatalf("stable sort broke (order should mirror Updated desc when Created ties): %v", keys(got))
+	}
+}
+
+func TestSort_ByUpdated_ordersIssues(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "", "x", nil, t0, t0.Add(2*time.Hour))
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "", "x", nil, t0, t0)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "", "x", nil, t0, t0.Add(time.Hour))
+
+	got := sortBy(t, []model.Issue{a, b, c}, list.SortKey{Column: list.ColUpdated, Desc: true})
+	wantOrder := []string{"ABC-1", "ABC-3", "ABC-2"}
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_BySummary_caseInsensitive(t *testing.T) {
+	now := time.Now()
+	a := mkSortIssue("ABC-1", "Bug", "To Do", "", "banana", nil, now, now)
+	b := mkSortIssue("ABC-2", "Bug", "To Do", "", "Apple", nil, now, now)
+	c := mkSortIssue("ABC-3", "Bug", "To Do", "", "cherry", nil, now, now)
+
+	got := sortBy(t, []model.Issue{a, b, c}, list.SortKey{Column: list.ColSummary, Desc: false})
+	wantOrder := []string{"ABC-2", "ABC-1", "ABC-3"}
+	for i, k := range wantOrder {
+		if got[i].Key != k {
+			t.Fatalf("pos %d = %q, want %q (full=%v)", i, got[i].Key, k, keys(got))
+		}
+	}
+}
+
+func TestSort_MultiKey_secondaryActsAsTiebreaker(t *testing.T) {
+	now := time.Now()
+	bug1 := mkSortIssue("ABC-1", "Bug", "Done", "", "x", nil, now, now)
+	bug2 := mkSortIssue("ABC-2", "Bug", "To Do", "", "x", nil, now, now)
+	task1 := mkSortIssue("ABC-3", "Task", "Done", "", "x", nil, now, now)
+	task2 := mkSortIssue("ABC-4", "Task", "To Do", "", "x", nil, now, now)
+
+	// Sort by Type asc, then Status asc within each Type bucket.
+	got := sortBy(t, []model.Issue{bug2, task1, bug1, task2},
+		list.SortKey{Column: list.ColType, Desc: false},
+		list.SortKey{Column: list.ColStatus, Desc: false},
+	)
+	want := []string{"ABC-1", "ABC-2", "ABC-3", "ABC-4"}
+	for i, k := range want {
+		if got[i].Key != k {
+			t.Fatalf("multi-key sort: pos %d = %q, want %q", i, got[i].Key, k)
+		}
+	}
+}
+
+func keys(issues []model.Issue) []string {
+	out := make([]string, len(issues))
+	for i, iss := range issues {
+		out[i] = iss.Key
+	}
+	return out
+}

--- a/internal/tui/root_encode_test.go
+++ b/internal/tui/root_encode_test.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/anttti/j/internal/model"
+	"github.com/anttti/j/internal/tui/appstate"
+	"github.com/anttti/j/internal/tui/list"
+)
+
+// These tests exercise the persistence-layer encode/decode helpers in
+// root.go. They are unexported but live in the same package, so we use an
+// internal _test.go (same package) to drive them. Each test asserts a
+// round-trip preserves the value.
+
+func TestEncodeDecodeFilter_RoundTripsAllAssigneeKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		in   model.Filter
+	}{
+		{
+			"all",
+			model.Filter{
+				Types:    []string{"Bug", "Task"},
+				Statuses: []string{"To Do"},
+				Assignee: model.AssigneeAll(),
+				Search:   "flake",
+			},
+		},
+		{
+			"me",
+			model.Filter{
+				Types:    nil,
+				Statuses: nil,
+				Assignee: model.AssigneeMe(),
+			},
+		},
+		{
+			"unassigned",
+			model.Filter{
+				Assignee: model.AssigneeUnassigned(),
+			},
+		},
+		{
+			"account",
+			model.Filter{
+				Assignee: model.AssigneeAccount("acc-42"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := decodeFilter(encodeFilter(tc.in))
+			if !reflect.DeepEqual(normalizeFilter(out), normalizeFilter(tc.in)) {
+				t.Fatalf("round trip mismatch:\n got: %+v\nwant: %+v", out, tc.in)
+			}
+		})
+	}
+}
+
+func TestDecodeFilter_UnknownAssigneeKindFallsBackToAll(t *testing.T) {
+	got := decodeFilter(appstate.Filter{Assignee: appstate.Assignee{Kind: "weird"}})
+	if got.Assignee.Kind != model.AssigneeKindAll {
+		t.Fatalf("kind=%v want All", got.Assignee.Kind)
+	}
+}
+
+func TestEncodeDecodeSort_RoundTrip(t *testing.T) {
+	in := []list.SortKey{
+		{Column: list.ColPrio, Desc: false},
+		{Column: list.ColUpdated, Desc: true},
+	}
+	got := decodeSort(encodeSort(in))
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("round trip:\n got=%+v\nwant=%+v", got, in)
+	}
+}
+
+func TestEncodeSort_NilForEmpty(t *testing.T) {
+	if got := encodeSort(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+	if got := decodeSort(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestEncodeDecodeColumns_RoundTrip(t *testing.T) {
+	in := []list.ColumnID{list.ColKey, list.ColStatus, list.ColSummary}
+	got := decodeColumns(encodeColumns(in))
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("round trip:\n got=%+v\nwant=%+v", got, in)
+	}
+}
+
+func TestEncodeDecodeColumns_NilForEmpty(t *testing.T) {
+	if got := encodeColumns(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+	if got := decodeColumns(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestEncodeDecodePresets_RoundTrip(t *testing.T) {
+	in := map[int][]list.ColumnID{
+		1: {list.ColKey, list.ColSummary},
+		3: {list.ColKey, list.ColStatus, list.ColPrio},
+	}
+	got := decodePresets(encodePresets(in))
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("round trip:\n got=%+v\nwant=%+v", got, in)
+	}
+}
+
+func TestEncodePresets_NilForEmpty(t *testing.T) {
+	if got := encodePresets(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+	if got := decodePresets(nil); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestDecodePresets_SkipsNonIntegerSlots(t *testing.T) {
+	in := map[string][]string{
+		"1":   {"key"},
+		"abc": {"summary"}, // bogus slot, must be skipped
+		"2":   {"status"},
+	}
+	got := decodePresets(in)
+	if _, ok := got[1]; !ok {
+		t.Fatalf("missing slot 1: %+v", got)
+	}
+	if _, ok := got[2]; !ok {
+		t.Fatalf("missing slot 2: %+v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 valid slots, got %d: %+v", len(got), got)
+	}
+}
+
+// normalizeFilter swaps nil/empty slice variants so reflect.DeepEqual ignores
+// the difference: encodeFilter produces empty slices, model.Filter often has
+// nil. We compare the meaningful identity of the value.
+func normalizeFilter(f model.Filter) model.Filter {
+	if len(f.Types) == 0 {
+		f.Types = nil
+	}
+	if len(f.Statuses) == 0 {
+		f.Statuses = nil
+	}
+	return f
+}

--- a/internal/tui/style/style_test.go
+++ b/internal/tui/style/style_test.go
@@ -1,0 +1,153 @@
+package style_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anttti/j/internal/tui/style"
+)
+
+func TestInitials(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "?"},
+		{"whitespace", "   ", "?"},
+		{"single name", "Alice", "A"},
+		{"first last", "Alice Wonder", "AW"},
+		{"three names uses first+last", "Alice B Wonder", "AW"},
+		{"lowercase upcased", "alice wonder", "AW"},
+		{"non-letter prefix skipped", "@alice", "A"},
+		{"digits ok", "1stPlace", "1"},
+		{"all symbols", "***", "?"},
+		{"hyphenated last name kept whole", "Mary Jane-Smith", "MJ"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := style.Initials(tc.in); got != tc.want {
+				t.Fatalf("Initials(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAssigneeColor_StableForSameID(t *testing.T) {
+	a := style.AssigneeColor("acc-1")
+	b := style.AssigneeColor("acc-1")
+	if a != b {
+		t.Fatalf("expected stable color, got %v vs %v", a, b)
+	}
+}
+
+func TestAssigneeColor_EmptyIDReturnsMutedColor(t *testing.T) {
+	c := style.AssigneeColor("")
+	if c == "" {
+		t.Fatalf("expected non-empty color for empty id")
+	}
+}
+
+func TestAssigneeColor_DifferentIDsCoverPalette(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 200; i++ {
+		seen[string(style.AssigneeColor(string(rune('a'+i%26))+string(rune('A'+i%26))+string(rune('0'+i%10))))] = true
+	}
+	if len(seen) < 4 {
+		t.Fatalf("palette should yield several distinct colors; saw %d", len(seen))
+	}
+}
+
+func TestStatusStyle_PicksColorByCategory(t *testing.T) {
+	done := style.StatusStyle("done").GetForeground()
+	indet := style.StatusStyle("indeterminate").GetForeground()
+	todo := style.StatusStyle("todo").GetForeground()
+	other := style.StatusStyle("anything-else").GetForeground()
+	if done == indet || done == todo || done == other {
+		t.Fatalf("done should differ from other categories: %v %v %v %v", done, indet, todo, other)
+	}
+	if got := style.StatusStyle("new").GetForeground(); got != todo {
+		t.Fatalf("'new' should be styled like 'todo': %v vs %v", got, todo)
+	}
+	if got := style.StatusStyle("DONE").GetForeground(); got != done {
+		t.Fatalf("status style should be case-insensitive")
+	}
+}
+
+func TestPriorityStyle_PicksColorByName(t *testing.T) {
+	high := style.PriorityStyle("High").GetForeground()
+	highest := style.PriorityStyle("Highest").GetForeground()
+	medium := style.PriorityStyle("Medium").GetForeground()
+	low := style.PriorityStyle("Low").GetForeground()
+	other := style.PriorityStyle("???").GetForeground()
+	if high != highest {
+		t.Fatalf("high and highest should share style: %v vs %v", high, highest)
+	}
+	if high == medium || high == low || high == other {
+		t.Fatalf("high should differ from medium/low/other: %v %v %v %v", high, medium, low, other)
+	}
+	if got := style.PriorityStyle("LOWEST").GetForeground(); got != low {
+		t.Fatalf("priority should be case-insensitive")
+	}
+}
+
+func TestTypeStyle_PicksColorByName(t *testing.T) {
+	bug := style.TypeStyle("Bug").GetForeground()
+	story := style.TypeStyle("Story").GetForeground()
+	epic := style.TypeStyle("Epic").GetForeground()
+	task := style.TypeStyle("Task").GetForeground()
+	subtask := style.TypeStyle("Sub-task").GetForeground()
+	other := style.TypeStyle("Custom").GetForeground()
+	if bug == story || story == epic || epic == task || task == other {
+		t.Fatalf("each type should have distinct style")
+	}
+	if task != subtask {
+		t.Fatalf("task and sub-task should share style")
+	}
+	if got := style.TypeStyle("subtask").GetForeground(); got != subtask {
+		t.Fatalf("'subtask' should equal 'sub-task'")
+	}
+}
+
+func TestTypeSymbol(t *testing.T) {
+	cases := map[string]string{
+		"Bug":      "■",
+		"Story":    "◆",
+		"Epic":     "★",
+		"Task":     "▲",
+		"Sub-task": "↳",
+		"subtask":  "↳",
+		"unknown":  "●",
+		"":         "●",
+	}
+	for in, want := range cases {
+		if got := style.TypeSymbol(in); got != want {
+			t.Errorf("TypeSymbol(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestModePill_RendersLabelText(t *testing.T) {
+	for _, mode := range []string{"NORMAL", "INSERT", "COMMAND", "OTHER"} {
+		out := style.ModePill(mode)
+		if !strings.Contains(out, mode) {
+			t.Fatalf("ModePill(%q) missing label text in: %q", mode, out)
+		}
+	}
+}
+
+func TestHorizontalRule_WidthClampsToOne(t *testing.T) {
+	if got := style.HorizontalRule(0); !strings.Contains(got, "─") {
+		t.Fatalf("HorizontalRule(0) should still render at least one rune: %q", got)
+	}
+	if got := style.HorizontalRule(-5); !strings.Contains(got, "─") {
+		t.Fatalf("HorizontalRule(-5) should still render at least one rune: %q", got)
+	}
+}
+
+func TestHorizontalRule_WidthEqualsRequested(t *testing.T) {
+	out := style.HorizontalRule(8)
+	if strings.Count(out, "─") != 8 {
+		t.Fatalf("HorizontalRule(8) should contain 8 runes; got %q", out)
+	}
+}


### PR DESCRIPTION
Audit the codebase for testability gaps and add unit tests for pure
helpers and key behaviour that previously had 0% coverage:

- style: helpers for status/priority/type/symbol/initials/assignee color
- list/sort: applySort + compareByColumn driven via the public Model
- list helpers: relTime, looksLikeIssueKey, halfPage/pageSize, clamp,
  truncateEllipsis, computeColumnWidths, summarise* and assigneeLabel
- detail: Ctrl+D/U half-page scroll, arrow keys, [ clamp, W alias,
  index clamping, stale comment messages
- root: encode/decode round-trip for filter, sort, columns, and presets
- jira/adf: link/mention/heading-level/list/codeBlock/hardBreak/marks
- config: EnsureDefault create + idempotency, ParseDuration error
  paths, DefaultPath under HOME, end-to-end Load via t.Setenv
- cmd: NewRootCmd subcommand wiring and --help, Daemon loop with
  cancellation and error paths
- storetest: a self-test that runs the full conformance suite against
  memstore so its helpers report coverage

Refactor the platform package to inject a small commandRunner seam so
the Opener/Clipboard fallback chains (open → xdg-open, pbcopy →
wl-copy → xclip) can be exercised in tests without shelling out.
The default behaviour is unchanged.